### PR TITLE
Small fix to allow shaders to change mid-program.

### DIFF
--- a/src/unsw/graphics/Application3D.java
+++ b/src/unsw/graphics/Application3D.java
@@ -58,6 +58,10 @@ public abstract class Application3D extends Application {
         // ... as is the view matrix
         Shader.setViewMatrix(gl, Matrix4.identity());
         
+        // Reshape is called here just to make sure that if the shader is changed,
+        // then the projection matrix property is set.
+        reshape(gl, getWindow().getWidth(), getWindow().getHeight());
+        
         Shader.setPenColor(gl, Color.BLACK);
     }
 


### PR DESCRIPTION
If a user were to call gl.glUseProgram() on another shader mid-execution, the projection matrix will not be set for the new shader program. I found this out when implementing this week's question 3. This change forces the reshape function to be called every frame just so that projection matrix is always set whenever the user switches shaders. There may be a more appropriate place for a fix, but this seems like a simple and inexpensive place to put this.